### PR TITLE
update header links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ faviconUrl: /assets/images/favicon.ico
 header_links:
   - text: Try the web app
     fa_class: fa fa-flask
-    url: http://threatdragon.org
+    url: https://www.threatdragon.com/#/
 
   - text: Download the desktop app
     fa_class: fa fa-cloud-download-alt
     target: _blank
-    url: https://github.com/OWASP/threat-dragon-desktop/releases
+    url: https://github.com/OWASP/threat-dragon/releases
 
   - text: Visit us on GitHub
     fa_class: fab fa-github

--- a/_config.yaml
+++ b/_config.yaml
@@ -6,12 +6,12 @@ faviconUrl: /assets/images/favicon.ico
 header_links:
   - text: Try the web app
     fa_class: fa fa-flask
-    url: http://threatdragon.org
+    url: https://www.threatdragon.com/#/
 
   - text: Download the desktop app
     fa_class: fa fa-cloud-download-alt
     target: _blank
-    url: https://github.com/OWASP/threat-dragon-desktop/releases
+    url: https://github.com/OWASP/threat-dragon/releases
 
   - text: Visit us on GitHub
     fa_class: fab fa-github


### PR DESCRIPTION
This updates the 'flask' to point to the new www.threatdragon.com application, and the 'cloud' download link now points to the OWASP area releases