### PR TITLE
Refactoring Release Process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,19 +2,21 @@ name: Release Gem
 
 on:
   push:
-    branches: [ "main" ]
+    tags: [ "v*" ]
 
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       id-token: write
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,29 +28,18 @@ jobs:
           gem install bundler
           bundle install
 
-      - name: Bump gemspec version
+      - name: Set gemspec version from tag
         run: |
           GEMSPEC_FILE="owasp-td-jekyll.gemspec"
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Tag version: $TAG_VERSION"
+
           CURRENT_VERSION=$(grep -E "spec.version\s*=" "$GEMSPEC_FILE" | sed -E "s/.*['\"]([0-9]+\.[0-9]+\.[0-9]+)['\"].*/\1/")
+          echo "Gemspec version before: $CURRENT_VERSION"
 
-          echo "Current version: $CURRENT_VERSION"
+          sed -i -E "s/(spec\.version\s*=\s*['\"])$CURRENT_VERSION(['\"])/\1$TAG_VERSION\2/" "$GEMSPEC_FILE"
 
-          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-          patch=$((patch + 1))
-          NEW_VERSION="$major.$minor.$patch"
-
-          echo "New version: $NEW_VERSION"
-
-          sed -i -E "s/(spec\.version\s*=\s*['\"])$CURRENT_VERSION(['\"])/\1$NEW_VERSION\2/" "$GEMSPEC_FILE"
-
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
-          git add .
-          git commit -m "Bump gemspec version to $NEW_VERSION [skip ci]"
-          git tag "v$NEW_VERSION"
-          git push origin "v$NEW_VERSION"
-          git push origin HEAD
+          echo "Gemspec version set to: $TAG_VERSION"
 
       - name: Build gem
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Releasing
+
+Version lives in `owasp-td-jekyll.gemspec`. Releases are driven by tags, not by pushing to main.
+
+1. Bump the version in the gemspec (e.g. patch: 1.0.2 → 1.0.3) in a PR and merge to main.
+2. From main, create and push a tag whose version matches: `git tag v1.0.3 && git push origin v1.0.3`.
+3. The release workflow runs on tag push: it sets the gemspec to the tag version, builds the gem, and publishes to RubyGems.
+
+Tag format must be `v` plus the version (e.g. `v1.0.3`).


### PR DESCRIPTION
Closes #14 
Updates the release process to be triggered by tags starting in `v*`
We are using "trusted publisher" for releasing, there is no more rubygems token and it has been disabled in my rubygems account.

## AI Disclaimer
I had some help from Cursor on this one.  I manually reviewed and modified the changes.  Where this is an action for releasing, I will need to test manually anyways.