### PR TITLE
Making all tables have the same style as table-striped

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -218,6 +218,45 @@ body {
   border-radius: 0;
 }
 
+/* Default all tables to Bootstrap's .table + .table-striped styling. */
+table {
+  --bs-table-color-type: initial;
+  --bs-table-bg-type: initial;
+  --bs-table-color-state: initial;
+  --bs-table-bg-state: initial;
+  --bs-table-color: var(--bs-emphasis-color);
+  --bs-table-bg: var(--bs-body-bg);
+  --bs-table-border-color: var(--bs-border-color);
+  --bs-table-accent-bg: transparent;
+  --bs-table-striped-color: var(--bs-emphasis-color);
+  --bs-table-striped-bg: rgba(var(--bs-emphasis-color-rgb), 0.05);
+  width: 100%;
+  margin-bottom: 1rem;
+  vertical-align: top;
+  border-color: var(--bs-table-border-color);
+}
+
+table > :not(caption) > * > * {
+  padding: 0.5rem 0.5rem;
+  color: var(--bs-table-color-state, var(--bs-table-color-type, var(--bs-table-color)));
+  background-color: var(--bs-table-bg);
+  border-bottom-width: var(--bs-border-width);
+  box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
+}
+
+table > tbody {
+  vertical-align: inherit;
+}
+
+table > thead {
+  vertical-align: bottom;
+}
+
+table > tbody > tr:nth-of-type(odd) > * {
+  --bs-table-color-type: var(--bs-table-striped-color);
+  --bs-table-bg-type: var(--bs-table-striped-bg);
+}
+
 .text-left {
   text-align: left !important;
 }

--- a/env/environment.md
+++ b/env/environment.md
@@ -7,3 +7,30 @@ nav_order: 0
 ---
 # Env Setup
 blah blah blah
+
+## Test Table
+
+I've updated the styles so that tables will always inherit from Bootstrap's `.table-striped`, as the spacing is better and it's easier to read.  This is a test table.
+
+|Name|Default|Description|
+|---|---|---|
+|LOG_LEVEL|`info`|The level at which to log.  Debug is most verbose, error is least verbose but you may miss important context|
+|APP_PORT|`3000`|What port the server should listen on|
+|SOMETHING||Something that does a thing|
+
+## Code Blocks
+
+Code blocks need to be readable.  While I'm not interested in adding a dependency for code highlighting, the code blocks should at least be distinguishable from regular text.
+
+```javascript
+
+const foo = 'bar';
+
+const getFoo = () => {
+  return foo; // Why would you even do this?
+};
+
+console.warn('heyyo');
+```
+
+


### PR DESCRIPTION
Closes #16 

Updates the main styles so that all tables use the table-striped styles automatically.  This will prevent having to manually add classes and other hacky markdown workarounds.