### PR TITLE
Code Styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .sass-cache
 _site
 vendor
+!assets/css/vendor/
+!assets/css/vendor/rouge-friendly.css
+!assets/css/vendor/rouge-friendly.UNLICENSE.txt

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
     <link rel="shortcut icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">
     <link rel="icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">
     <link rel="stylesheet" href="{{ '/assets/css/bootstrap.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/vendor/rouge-friendly.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/fontawesome.min.css' | relative_url }}">
 </head>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,6 +2,11 @@
   --td-orange: #e95420;
   --td-dark-orange: #97310e;
   --td-gray: #aea79f;
+  --td-light-gray: #f1f3f5;
+  --td-code-block-bg: #f0f0f0;
+  --td-code-bg: #ece7e1;
+  --td-code-border: #d3cbc1;
+  --td-inline-code-color: #b02267;
   --td-white: #ffffff;
   --td-black: #333333;
   --bs-primary: var(--td-orange);
@@ -196,6 +201,42 @@ body {
 
 .btn-secondary {
   color: var(--td-white) !important;
+}
+
+/* Improve readability of fenced code blocks and inline code. */
+.highlighter-rouge .highlight,
+pre.highlight {
+  background-color: var(--td-code-block-bg);
+  border: 1px solid var(--td-code-border);
+  border-radius: var(--bs-border-radius);
+}
+
+.highlighter-rouge .highlight pre,
+pre.highlight {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  color: var(--td-black);
+  background-color: transparent;
+}
+
+.highlighter-rouge .highlight pre code,
+pre.highlight code {
+  color: var(--td-black);
+  background-color: transparent;
+}
+
+p code,
+li code,
+td code,
+th code {
+  padding: 0.1rem 0.3rem;
+  color: var(--td-inline-code-color);
+  background-color: var(--td-code-bg);
+  font-size: 0.95em;
+  font-weight: 500;
+  line-height: 1.3;
+  border-radius: 0.2rem;
 }
 
 /* Bootstrap 4 compatibility helpers used by site content/layouts. */

--- a/assets/css/vendor/rouge-friendly.UNLICENSE.txt
+++ b/assets/css/vendor/rouge-friendly.UNLICENSE.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/assets/css/vendor/rouge-friendly.css
+++ b/assets/css/vendor/rouge-friendly.css
@@ -1,0 +1,70 @@
+/* Vendored from richleland/pygments-css (friendly.css), UNLICENSE. */
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f0f0f0; }
+.highlight .c { color: #60a0b0; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #007020; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #60a0b0; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #007020 } /* Comment.Preproc */
+.highlight .cpf { color: #60a0b0; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #007020 } /* Keyword.Pseudo */
+.highlight .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #902000 } /* Keyword.Type */
+.highlight .m { color: #40a070 } /* Literal.Number */
+.highlight .s { color: #4070a0 } /* Literal.String */
+.highlight .na { color: #4070a0 } /* Name.Attribute */
+.highlight .nb { color: #007020 } /* Name.Builtin */
+.highlight .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.highlight .no { color: #60add5 } /* Name.Constant */
+.highlight .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #007020 } /* Name.Exception */
+.highlight .nf { color: #06287e } /* Name.Function */
+.highlight .nl { color: #002070; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #062873; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #bb60d5 } /* Name.Variable */
+.highlight .ow { color: #007020; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #40a070 } /* Literal.Number.Bin */
+.highlight .mf { color: #40a070 } /* Literal.Number.Float */
+.highlight .mh { color: #40a070 } /* Literal.Number.Hex */
+.highlight .mi { color: #40a070 } /* Literal.Number.Integer */
+.highlight .mo { color: #40a070 } /* Literal.Number.Oct */
+.highlight .sa { color: #4070a0 } /* Literal.String.Affix */
+.highlight .sb { color: #4070a0 } /* Literal.String.Backtick */
+.highlight .sc { color: #4070a0 } /* Literal.String.Char */
+.highlight .dl { color: #4070a0 } /* Literal.String.Delimiter */
+.highlight .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #4070a0 } /* Literal.String.Double */
+.highlight .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #4070a0 } /* Literal.String.Heredoc */
+.highlight .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #c65d09 } /* Literal.String.Other */
+.highlight .sr { color: #235388 } /* Literal.String.Regex */
+.highlight .s1 { color: #4070a0 } /* Literal.String.Single */
+.highlight .ss { color: #517918 } /* Literal.String.Symbol */
+.highlight .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06287e } /* Name.Function.Magic */
+.highlight .vc { color: #bb60d5 } /* Name.Variable.Class */
+.highlight .vg { color: #bb60d5 } /* Name.Variable.Global */
+.highlight .vi { color: #bb60d5 } /* Name.Variable.Instance */
+.highlight .vm { color: #bb60d5 } /* Name.Variable.Magic */
+.highlight .il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/env/environment.md
+++ b/env/environment.md
@@ -23,7 +23,6 @@ I've updated the styles so that tables will always inherit from Bootstrap's `.ta
 Code blocks need to be readable.  While I'm not interested in adding a dependency for code highlighting, the code blocks should at least be distinguishable from regular text.
 
 ```javascript
-
 const foo = 'bar';
 
 const getFoo = () => {
@@ -33,4 +32,15 @@ const getFoo = () => {
 console.warn('heyyo');
 ```
 
+---
 
+
+```python
+# The main code
+def main():
+    print("Hello, world!")
+
+if __name__ == "__main__":
+    main()
+
+```


### PR DESCRIPTION
Closes #18 
Closes #19 

Updating the styles for both inline code and code blocks.
Jekyll is already marking up the code based on the language flag for syntax highlighting. There is no need for a JavaScript dependency, only CSS.  We are leveraging a well-loved open-source stylesheet (UNLICENSE licensed, included) that provides better syntax highlighting.