### PR TITLE
Restoring mobile nav, improving styles and ux

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
     <title>{{ page.title }}</title>
 
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <link rel="shortcut icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">
     <link rel="icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,14 +1,26 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     {%- assign search_text = site.search.text -%}
     {%- assign search_tooltip = site.search.tooltip -%}
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+    {%- assign search_label = search_tooltip | default: search_text | default: 'Search documentation' -%}
+    <button class="navbar-toggler d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="{{ '/' | relative_url }}">
         {{ site.brand }}
     </a>
+    <button
+        class="nav-link theme-toggle td-mobile-theme-toggle d-md-none ms-auto"
+        type="button"
+        data-theme-toggle
+        data-theme-tooltip-dark="{{ site.theme_toggle.dark_tooltip | default: 'Switch to dark mode' }}"
+        data-theme-tooltip-light="{{ site.theme_toggle.light_tooltip | default: 'Switch to light mode' }}"
+        aria-label="Switch to dark mode"
+        title="Switch to dark mode">
+        <i class="fas fa-moon theme-toggle-icon" aria-hidden="true"></i>
+        <span class="visually-hidden" data-theme-toggle-label>Switch to dark mode</span>
+    </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
-        <ul class="navbar-nav ms-auto">
+        <ul class="navbar-nav ms-auto d-none d-md-flex">
             <li class="nav-item">
                 <a
                     class="nav-link active"
@@ -16,7 +28,7 @@
                     role="button"
                     data-bs-toggle="modal"
                     data-bs-target="#tdSearchModal"
-                    aria-label="{{ search_tooltip | default: search_text | default: 'Search documentation' }}"
+                    aria-label="{{ search_label }}"
                     {% if search_tooltip %}title="{{ search_tooltip }}" data-bs-toggle-tooltip="tooltip" data-bs-placement="bottom"{% endif %}>
                     <i class="fas fa-search fa-lg" aria-hidden="true"></i>
                     {%- if search_text and search_text != '' -%} {{ search_text }}{%- else -%}<span class="visually-hidden">Search</span>{%- endif -%}
@@ -25,27 +37,17 @@
             {%- for navlink in site.header_links -%}
             <li class="nav-item">
                 <a href="{{ navlink.url }}"
-                    {% if navlink.target %} target="{{ navlink.target }}" rel="noopener noreferrer"{%- endif -%}
+                    {% if navlink.target %} target="{{ navlink.target }}" rel="noopener noreferrer"{% endif %}
                     class="nav-link active"
                     {% if navlink.tooltip or navlink.text %}aria-label="{{ navlink.tooltip | default: navlink.text }}"{% endif %}
                     {% if navlink.tooltip %}title="{{ navlink.tooltip }}" data-bs-toggle-tooltip="tooltip" data-bs-placement="bottom"{% endif %}>
-                        {%- if navlink.fa_class -%}
-                        <i class="{{ navlink.fa_class }} fa-lg"></i>
-                        {%- endif -%}
-                        {%- if navlink.text and navlink.text != '' -%} {{ navlink.text }}{%- endif -%}
+                    {%- if navlink.fa_class -%}
+                    <i class="{{ navlink.fa_class }} fa-lg"></i>
+                    {%- endif -%}
+                    {%- if navlink.text and navlink.text != '' -%} {{ navlink.text }}{%- endif -%}
                 </a>
             </li>
             {%- endfor -%}
-            
-            <!-- Sidebars do not work well on smaller devices.  We want to fall back to a more traditional expanding button navigation -->
-            <li class="nav-item dropdown d-sm-block d-md-none">
-                <a class="nav-link dropdown-toggle" href="#" id="smallerscreenmenu" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> Menu </a>
-                <div class="dropdown-menu" aria-labelledby="smallerscreenmenu">
-                    {%- for navPage in site.pages | where: "path" -%}
-                        <a class="dropdown-item" href="{{ navPage.url || relative_url }}">{{ navPage.title }}</a>
-                    {%- endfor -%}
-                </div>
-            </li>
             <li class="nav-item">
                 {%- assign theme_toggle_text = site.theme_toggle.text -%}
                 <button
@@ -65,5 +67,92 @@
                 </button>
             </li>
         </ul>
+        <div class="td-mobile-menu d-md-none">
+            <div class="td-mobile-menu-panel">
+                <a class="td-mobile-menu-link{% if page.url == '/' %} active{%- endif -%}" href="{{ '/' | relative_url }}">
+                    <span class="td-mobile-menu-icon"><i class="fas fa-home" aria-hidden="true"></i></span>
+                    <span class="td-mobile-menu-text">Home</span>
+                </a>
+                <button
+                    class="td-mobile-menu-link td-mobile-menu-button"
+                    type="button"
+                    data-bs-toggle="modal"
+                    data-bs-target="#tdSearchModal"
+                    aria-label="{{ search_label }}">
+                    <span class="td-mobile-menu-icon"><i class="fas fa-search" aria-hidden="true"></i></span>
+                    <span class="td-mobile-menu-text">{{ search_text | default: 'Search' }}</span>
+                </button>
+                {%- if site.header_links and site.header_links.size > 0 -%}
+                <button
+                    class="td-mobile-menu-link td-mobile-menu-button td-mobile-menu-toggle"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#mobile-project-links"
+                    aria-expanded="false"
+                    aria-controls="mobile-project-links">
+                    <span class="td-mobile-menu-icon"><i class="fas fa-link" aria-hidden="true"></i></span>
+                    <span class="td-mobile-menu-text">Project Links</span>
+                    <span class="td-mobile-menu-caret fa fa-caret-down" aria-hidden="true"></span>
+                </button>
+                <div id="mobile-project-links" class="collapse td-mobile-menu-section">
+                    {%- for navlink in site.header_links -%}
+                    <a href="{{ navlink.url }}"
+                        {% if navlink.target %} target="{{ navlink.target }}" rel="noopener noreferrer"{% endif %}
+                        class="td-mobile-menu-link td-mobile-menu-sublink"
+                        {% if navlink.tooltip or navlink.text %}aria-label="{{ navlink.tooltip | default: navlink.text }}"{% endif %}>
+                        <span class="td-mobile-menu-icon">
+                            {%- if navlink.fa_class -%}
+                            <i class="{{ navlink.fa_class }}" aria-hidden="true"></i>
+                            {%- endif -%}
+                        </span>
+                        <span class="td-mobile-menu-text">{{ navlink.text | default: navlink.tooltip | default: navlink.url }}</span>
+                    </a>
+                    {%- endfor -%}
+                </div>
+                {%- endif -%}
+                {%- for category in site.nav.categories -%}
+                {%- assign categoryActive = false -%}
+                {%- for group in category.groups -%}
+                    {%- assign categoryPages = site.pages | where_exp: "navPage", "navPage.group == group.name" -%}
+                    {%- assign categoryActiveCount = categoryPages | where_exp: "groupPage", "groupPage.url == page.url" | size -%}
+                    {%- if categoryActiveCount > 0 -%}
+                        {%- assign categoryActive = true -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {%- capture mobileCategoryId -%}mobile-category-{{ forloop.index }}{%- endcapture -%}
+                <button
+                    class="td-mobile-menu-link td-mobile-menu-button td-mobile-menu-toggle{% if categoryActive %} active{%- endif -%}"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#{{ mobileCategoryId }}"
+                    aria-expanded="false"
+                    aria-controls="{{ mobileCategoryId }}">
+                    <span class="td-mobile-menu-icon"><i class="fas fa-folder" aria-hidden="true"></i></span>
+                    <span class="td-mobile-menu-text">{{ category.name }}</span>
+                    <span class="td-mobile-menu-caret fa fa-caret-down" aria-hidden="true"></span>
+                </button>
+                <div id="{{ mobileCategoryId }}" class="collapse td-mobile-menu-section">
+                    {%- for group in category.groups -%}
+                        {%- assign pages = site.pages | where_exp: "navPage", "navPage.group == group.name" | sort: "nav_order" -%}
+                        {%- assign activeCount = pages | where_exp: "groupPage", "groupPage.url == page.url" | size -%}
+                        {%- if pages.size == 1 -%}
+                    <a class="td-mobile-menu-link td-mobile-menu-sublink{% if activeCount > 0 %} active{%- endif -%}" href="{{ pages.first.url | relative_url }}">
+                        <span class="td-mobile-menu-icon"><i class="{{ group.fa_class }}" aria-hidden="true"></i></span>
+                        <span class="td-mobile-menu-text">{{ group.name }}</span>
+                    </a>
+                        {%- elsif pages.size > 1 -%}
+                    <div class="td-mobile-menu-group-label{% if activeCount > 0 %} active{%- endif -%}">
+                        <span class="td-mobile-menu-icon"><i class="{{ group.fa_class }}" aria-hidden="true"></i></span>
+                        <span class="td-mobile-menu-text">{{ group.name }}</span>
+                    </div>
+                            {%- for navPage in pages -%}
+                    <a class="td-mobile-menu-link td-mobile-menu-sublink td-mobile-menu-childlink{% if page.url == navPage.url %} active{%- endif -%}" href="{{ navPage.url | relative_url }}">{{ navPage.title }}</a>
+                            {%- endfor -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                </div>
+                {%- endfor -%}
+            </div>
+        </div>
     </div>
 </nav>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="{{ '/assets/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/mobile-nav.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/sidebar.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/tooltips.js' | relative_url }}"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,6 +19,13 @@
   --td-navbar-link-hover-color: var(--td-white);
   --td-navbar-toggler-border: rgba(255, 255, 255, 0.1);
   --td-theme-toggle-hover-bg: rgba(255, 255, 255, 0.12);
+  --td-mobile-menu-bg: rgba(255, 255, 255, 0.98);
+  --td-mobile-menu-border: rgba(51, 51, 51, 0.12);
+  --td-mobile-menu-hover-bg: rgba(233, 84, 32, 0.08);
+  --td-mobile-menu-section-bg: rgba(51, 51, 51, 0.04);
+  --td-mobile-menu-text-color: var(--td-text-color);
+  --td-mobile-menu-muted-color: rgba(51, 51, 51, 0.62);
+  --td-mobile-menu-active-bg: rgba(233, 84, 32, 0.14);
   --bs-primary: var(--td-orange);
   --bs-primary-rgb: 233, 84, 32;
   --bs-secondary: var(--td-gray);
@@ -65,6 +72,13 @@
   --td-navbar-link-hover-color: #ffffff;
   --td-navbar-toggler-border: rgba(245, 241, 234, 0.2);
   --td-theme-toggle-hover-bg: rgba(216, 114, 72, 0.2);
+  --td-mobile-menu-bg: #222931;
+  --td-mobile-menu-border: rgba(245, 241, 234, 0.08);
+  --td-mobile-menu-hover-bg: rgba(245, 241, 234, 0.06);
+  --td-mobile-menu-section-bg: rgba(0, 0, 0, 0.14);
+  --td-mobile-menu-text-color: var(--td-white);
+  --td-mobile-menu-muted-color: rgba(245, 241, 234, 0.68);
+  --td-mobile-menu-active-bg: rgba(216, 114, 72, 0.2);
   --bs-primary: var(--td-orange);
   --bs-primary-rgb: 216, 114, 72;
   --bs-secondary: var(--td-gray);
@@ -192,6 +206,122 @@ a:hover {
   line-height: 1;
 }
 
+.td-mobile-theme-toggle {
+  color: var(--td-white);
+  padding: 0.375rem 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.td-mobile-theme-toggle:hover,
+.td-mobile-theme-toggle:focus,
+.td-mobile-theme-toggle:focus-visible {
+  color: var(--td-white);
+}
+
+.td-mobile-menu {
+  width: 100%;
+  margin-top: 0.65rem;
+  padding: 0.7rem;
+  background-color: rgba(var(--bs-body-bg-rgb), 0.94);
+  border: 1px solid rgba(var(--bs-body-color-rgb), 0.08);
+  border-radius: 0.5rem;
+  box-shadow: 0 0.9rem 2.2rem rgba(0, 0, 0, 0.18);
+}
+
+.td-mobile-menu-panel {
+  background-color: var(--td-mobile-menu-bg);
+  border: 1px solid var(--td-mobile-menu-border);
+  border-radius: 0.35rem;
+  overflow: hidden;
+}
+
+.td-mobile-menu-link,
+.td-mobile-menu-group-label {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  width: 100%;
+  padding: 0.9rem 1rem;
+  color: var(--td-mobile-menu-text-color);
+  text-align: left;
+  text-decoration: none;
+  border-bottom: 1px solid var(--td-mobile-menu-border);
+}
+
+.td-mobile-menu-button {
+  background: transparent;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+}
+
+.td-mobile-menu-link:hover,
+.td-mobile-menu-link:focus-visible,
+.td-mobile-menu-button:hover,
+.td-mobile-menu-button:focus-visible {
+  color: var(--td-mobile-menu-text-color);
+  background-color: var(--td-mobile-menu-hover-bg);
+  text-decoration: none;
+}
+
+.td-mobile-menu-link.active {
+  background-color: var(--td-mobile-menu-active-bg);
+}
+
+.td-mobile-menu-group-label.active {
+  background-color: var(--td-mobile-menu-active-bg);
+  color: var(--td-mobile-menu-text-color);
+}
+
+.td-mobile-menu-icon {
+  width: 1.15rem;
+  flex-shrink: 0;
+  text-align: center;
+  color: inherit;
+}
+
+.td-mobile-menu-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.td-mobile-menu-caret {
+  flex-shrink: 0;
+  color: var(--td-mobile-menu-muted-color);
+  transition: transform 0.2s ease;
+}
+
+.td-mobile-menu-toggle[aria-expanded="true"] .td-mobile-menu-caret {
+  transform: rotate(180deg);
+}
+
+.td-mobile-menu-section {
+  background-color: var(--td-mobile-menu-section-bg);
+}
+
+.td-mobile-menu-group-label {
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--td-mobile-menu-muted-color);
+}
+
+.td-mobile-menu-sublink {
+  padding-left: 1.75rem;
+}
+
+.td-mobile-menu-childlink {
+  padding-left: 3rem;
+  font-size: 0.92rem;
+  color: var(--td-mobile-menu-text-color);
+}
+
+.td-mobile-menu-section > :last-child,
+.td-mobile-menu-panel > :last-child {
+  border-bottom: 0;
+}
+
 .td-search-modal .modal-content {
   background-color: var(--td-surface-bg);
   color: var(--bs-body-color);
@@ -314,25 +444,14 @@ a:hover {
   color: var(--bs-secondary-color, #6c757d);
 }
 
-#navbarToggler a {
-  color: var(--td-white);
-  padding: 18px;
-}
-
-@media (min-width: 992px) {
-  #navbarToggler a:hover {
-    background-color: var(--td-dark-orange);
-    text-decoration: none;
-  }
-}
-
 #body-row {
+  flex: 1 1 auto;
   margin-left: 0;
   margin-right: 0;
 }
 
 #sidebar-container {
-  min-height: 100vh;
+  min-height: 100%;
   background-color: var(--td-black);
   padding: 0;
 }
@@ -446,6 +565,9 @@ a:hover {
 }
 
 body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   font-family: "Ubuntu", Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 0.9rem;
   font-weight: 400;
@@ -716,6 +838,41 @@ table > tbody > tr:nth-of-type(odd) > * {
 }
 
 @media (max-width: 767.98px) {
+  .navbar {
+    position: relative;
+  }
+
+  .navbar-toggler.d-md-none {
+    margin-right: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .navbar .navbar-brand {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-right: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .navbar-collapse {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1020;
+    padding: 0 0.9rem 0.9rem;
+  }
+
+  #body-row {
+    margin-top: 0.625rem;
+  }
+
+  .td-mobile-theme-toggle .theme-toggle-text {
+    display: none;
+  }
+
   .td-search-modal .modal-dialog {
     margin: 0.75rem;
   }

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const mobileMediaQuery = window.matchMedia('(max-width: 767.98px)');
+    const navbar = document.querySelector('.navbar');
+    const navbarCollapse = document.getElementById('navbarNavDropdown');
+
+    if (!navbar || !navbarCollapse || !window.bootstrap || !window.bootstrap.Collapse) {
+        return;
+    }
+
+    const collapseInstance = window.bootstrap.Collapse.getOrCreateInstance(navbarCollapse, { toggle: false });
+
+    function hideMobileNav() {
+        if (mobileMediaQuery.matches && navbarCollapse.classList.contains('show')) {
+            collapseInstance.hide();
+        }
+    }
+
+    document.addEventListener('click', (event) => {
+        if (!mobileMediaQuery.matches || !navbarCollapse.classList.contains('show')) {
+            return;
+        }
+
+        if (!navbar.contains(event.target)) {
+            hideMobileNav();
+        }
+    });
+
+    navbarCollapse.querySelectorAll('.td-mobile-menu-link').forEach((element) => {
+        element.addEventListener('click', () => {
+            if (element.classList.contains('td-mobile-menu-toggle')) {
+                return;
+            }
+
+            hideMobileNav();
+        });
+    });
+
+    function handleViewportChange(event) {
+        if (!event.matches) {
+            collapseInstance.hide();
+        }
+    }
+
+    if (typeof mobileMediaQuery.addEventListener === 'function') {
+        mobileMediaQuery.addEventListener('change', handleViewportChange);
+    } else if (typeof mobileMediaQuery.addListener === 'function') {
+        mobileMediaQuery.addListener(handleViewportChange);
+    }
+});


### PR DESCRIPTION
Closes #33 

Restores the mobile menu - there was no viewport on the index, so the bootstrap breakpoints were not applying.
Ensured mobile nav looks right for both light and dark themes
Added active classes to mobile menu
Keeps light/dark switcher always available in navbar on mobile