### PR TITLE
Collapsed sidebar UX fix

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -99,13 +99,16 @@
                     <a href="{{ navlink.url }}"
                         {% if navlink.target %} target="{{ navlink.target }}" rel="noopener noreferrer"{% endif %}
                         class="td-mobile-menu-link td-mobile-menu-sublink"
-                        {% if navlink.tooltip or navlink.text %}aria-label="{{ navlink.tooltip | default: navlink.text }}"{% endif %}>
+                        aria-label="{{ navlink.tooltip | default: navlink.text | default: navlink.url }}{% if navlink.target %} (opens in new tab){% endif %}">
                         <span class="td-mobile-menu-icon">
                             {%- if navlink.fa_class -%}
                             <i class="{{ navlink.fa_class }}" aria-hidden="true"></i>
                             {%- endif -%}
                         </span>
                         <span class="td-mobile-menu-text">{{ navlink.text | default: navlink.tooltip | default: navlink.url }}</span>
+                        <span class="td-mobile-menu-meta" aria-hidden="true">
+                            <i class="fas fa-external-link-alt"></i>
+                        </span>
                     </a>
                     {%- endfor -%}
                 </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,7 +15,12 @@
                 <!-- TODO: Catpure groupActive and linkActive to apply classes and data props -->
                 {%- if pages.size == 1 -%}
                     <a href="{{ pages | map: 'url' | first | relative_url }}"
-                    class="bg-dark list-group-item list-group-item-action {% if activeCount > 0 %} active{%- endif -%}">
+                    class="bg-dark list-group-item list-group-item-action {% if activeCount > 0 %} active{%- endif -%}"
+                    data-sidebar-item="true"
+                    data-bs-toggle-tooltip="tooltip"
+                    data-bs-placement="right"
+                    title="{{ group.name }}"
+                    aria-label="{{ group.name }}">
                         <div class="d-flex w-100 justify-content-start align-items-center">
                             <span class="{{ group.fa_class }} fa-fw me-3"></span>
                             <span class="menu-collapsed sidebar-link-label">{{ group.name }}</span>
@@ -25,7 +30,13 @@
                     <a href="#{{ submenuId }}"
                         data-bs-toggle="collapse"
                         aria-expanded="{%- if activeCount > 0 -%}true{%- else -%}false{%- endif -%}"
-                        class="bg-dark list-group-item list-group-item-action grou-nav flex-column align-items-start {% if activeCount > 0 %} active{%- endif -%}">
+                        class="bg-dark list-group-item list-group-item-action grou-nav flex-column align-items-start {% if activeCount > 0 %} active{%- endif -%}"
+                        data-sidebar-item="true"
+                        data-sidebar-submenu="{{ submenuId }}"
+                        data-bs-toggle-tooltip="tooltip"
+                        data-bs-placement="right"
+                        title="{{ group.name }}"
+                        aria-label="{{ group.name }}">
                         <div class="d-flex w-100 justify-content-start align-items-center">
                             <span class="{{ group.fa_class }} fa-fw me-3"></span>
                             <span class="menu-collapsed sidebar-link-label">{{ group.name }}</span>
@@ -45,7 +56,7 @@
             {%- endfor -%}
         {%- endfor -%}
         
-            <a href="#top" data-sidebar-toggle="collapse" class="bg-dark list-group-item list-group-item-action d-flex align-items-center">
+            <a href="#top" data-sidebar-toggle="collapse" class="bg-dark list-group-item list-group-item-action d-flex align-items-center" data-bs-toggle-tooltip="tooltip" data-bs-placement="right" title="Toggle sidebar" aria-label="Toggle sidebar">
                 <div class="d-flex w-100 justify-content-start align-items-center">
                     <span id="collapse-icon" class="fa fa-angle-left fa-2x me-3"></span>
                     <span id="collapse-text" class="menu-collapsed">Collapse</span>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -291,6 +291,11 @@ a:hover {
   transition: transform 0.2s ease;
 }
 
+.td-mobile-menu-meta {
+  flex-shrink: 0;
+  color: var(--td-mobile-menu-muted-color);
+}
+
 .td-mobile-menu-toggle[aria-expanded="true"] .td-mobile-menu-caret {
   transform: rotate(180deg);
 }

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -3,11 +3,78 @@ document.querySelectorAll('#body-row .collapse').forEach((element) => {
     bootstrap.Collapse.getOrCreateInstance(element, { toggle: false }).hide();
 });
 
+function getSidebarContainer() {
+    return document.getElementById('sidebar-container');
+}
+
+function isSidebarCollapsed() {
+    return getSidebarContainer()?.classList.contains('sidebar-collapsed');
+}
+
+function setSidebarToggleLabel() {
+    const toggle = document.querySelector('[data-sidebar-toggle="collapse"]');
+    if (!toggle) {
+        return;
+    }
+
+    const label = isSidebarCollapsed() ? 'Expand sidebar' : 'Collapse sidebar';
+    toggle.setAttribute('title', label);
+    toggle.setAttribute('aria-label', label);
+    toggle.setAttribute('data-bs-original-title', label);
+}
+
+function syncSidebarTooltips() {
+    if (!window.bootstrap || !window.bootstrap.Tooltip) {
+        return;
+    }
+
+    document.querySelectorAll('[data-sidebar-item], [data-sidebar-toggle="collapse"]').forEach((element) => {
+        const tooltip = window.bootstrap.Tooltip.getInstance(element);
+        if (!tooltip) {
+            return;
+        }
+
+        if (isSidebarCollapsed()) {
+            tooltip.enable();
+        } else {
+            tooltip.hide();
+            tooltip.disable();
+        }
+    });
+}
+
+function expandSidebarSubmenu(submenuId) {
+    if (!submenuId || !window.bootstrap || !window.bootstrap.Collapse) {
+        return;
+    }
+
+    const submenu = document.getElementById(submenuId);
+    if (!submenu) {
+        return;
+    }
+
+    bootstrap.Collapse.getOrCreateInstance(submenu, { toggle: false }).show();
+}
+
 // Collapse click
 document.querySelectorAll('[data-sidebar-toggle="collapse"]').forEach((element) => {
     element.addEventListener('click', (event) => {
         event.preventDefault();
         SidebarCollapse();
+    });
+});
+
+document.querySelectorAll('[data-sidebar-item]').forEach((element) => {
+    element.addEventListener('click', (event) => {
+        if (!isSidebarCollapsed()) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        SidebarCollapse();
+        expandSidebarSubmenu(element.dataset.sidebarSubmenu);
+        element.focus();
     });
 });
 
@@ -22,7 +89,7 @@ function SidebarCollapse() {
     toggleClassForEach('.sidebar-submenu', 'd-none');
     toggleClassForEach('.submenu-icon', 'd-none');
 
-    const sidebarContainer = document.getElementById('sidebar-container');
+    const sidebarContainer = getSidebarContainer();
     if (sidebarContainer) {
         sidebarContainer.classList.toggle('sidebar-expanded');
         sidebarContainer.classList.toggle('sidebar-collapsed');
@@ -37,4 +104,12 @@ function SidebarCollapse() {
         collapseIcon.classList.toggle('fa-angle-left');
         collapseIcon.classList.toggle('fa-angle-right');
     }
+
+    setSidebarToggleLabel();
+    syncSidebarTooltips();
 }
+
+window.addEventListener('load', () => {
+    setSidebarToggleLabel();
+    syncSidebarTooltips();
+});


### PR DESCRIPTION
Closes #36 
The collapsed state of the sidebar was confusing - some icons were links, while others did nothing.
This was because of how we heavily leverage dropdowns in the side-nav, but led to a confusing user experience.
Now, clicking an icon in the collapsed sidebar will always just re-open the sidebar, and highlight the category you clicked (if not a direct link).

This  is still not a perfect implementation, but it's better than it was.

Additionally, I added the "external link" / "new window" type icons to the "Project Links" category in the mobile nav.