### PR TITLE
Add accessibility check and fix violations

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,6 +16,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+          cache: npm
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
@@ -24,8 +30,11 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
-      - name: Build site
-        run: bundle exec jekyll build
+      - name: Install accessibility tooling
+        run: npm ci
+
+      - name: Accessibility audit
+        run: npm run check:accessibility
 
       - name: Build gem
         run: gem build owasp-td-jekyll.gemspec

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+          cache: npm
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
@@ -27,6 +33,12 @@ jobs:
         run: |
           gem install bundler
           bundle install
+
+      - name: Install accessibility tooling
+        run: npm ci
+
+      - name: Accessibility audit
+        run: npm run check:accessibility
 
       - name: Set gemspec version from tag
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .sass-cache
 _site
 vendor
+node_modules
 !assets/css/vendor/
 !assets/css/vendor/rouge-friendly.css
 !assets/css/vendor/rouge-friendly.UNLICENSE.txt

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -5,7 +5,12 @@
   ],
   "rules": {
     "no-trailing-whitespace": "off",
-    "require-sri": "off",
+    "require-sri": [
+      "error",
+      {
+        "target": "crossorigin"
+      }
+    ],
     "void-style": "off"
   }
 }

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "html-validate:recommended",
+    "html-validate:document"
+  ],
+  "rules": {
+    "no-trailing-whitespace": "off",
+    "require-sri": "off",
+    "void-style": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/lreadi
 
 To set up your environment to develop this theme, run `bundle install`.
 
+To run the same accessibility baseline locally that CI uses, also install the Node dev dependency and run:
+
+```bash
+npm install
+npm run check:accessibility
+```
+
+That command rebuilds the Jekyll site and validates the generated HTML in `_site` with `html-validate`, giving a lightweight accessibility-focused baseline on pull requests and release builds. The check runs through plain `npm` scripts rather than a Bash wrapper, so it is friendlier to Windows contributors as well.
+
 Your theme is setup just like a normal Jekyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
 
 When your theme is released, only the files in `_layouts`, `_includes`, and `assets` tracked with Git will be bundled.

--- a/_config.yaml
+++ b/_config.yaml
@@ -1,5 +1,14 @@
 title: OWASP Threat Dragon
 
+exclude:
+  - README.md
+  - RELEASE.md
+  - Rakefile
+  - package.json
+  - package-lock.json
+  - owasp-td-jekyll.gemspec
+  - "*.gem"
+
 brand: OWASP Threat Dragon
 faviconUrl: /assets/images/favicon.ico
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,10 +1,10 @@
 
 <head>
-    <title>{{ page.title }}</title>
+    <title>{{ page.title }}{% if site.title %} | {{ site.title }}{% endif %}</title>
 
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="light dark" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
     <link rel="shortcut icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">
     <link rel="icon" href="{{ site.faviconUrl | relative_url }}" type="image/x-icon">
     <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>

--- a/_includes/home_links.html
+++ b/_includes/home_links.html
@@ -3,8 +3,8 @@
         <div class="col">
             <div class="jumbotron">
                 <div class="text-center">
-                    <a href="{{ link.relative_url | relative_url }}">
-                    <i class="{{ link.fa_class }} fa-4x"></i>
+                    <a href="{{ link.relative_url | relative_url }}" aria-label="{{ link.description | default: link.relative_url }}">
+                    <i class="{{ link.fa_class }} fa-4x" aria-hidden="true"></i>
                     </a>
                     <p class="mt-4">{{ link.description }}</p>
                 </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -22,17 +22,16 @@
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav ms-auto d-none d-md-flex">
             <li class="nav-item">
-                <a
+                <button
                     class="nav-link active"
-                    href="#"
-                    role="button"
+                    type="button"
                     data-bs-toggle="modal"
                     data-bs-target="#tdSearchModal"
                     aria-label="{{ search_label }}"
                     {% if search_tooltip %}title="{{ search_tooltip }}" data-bs-toggle-tooltip="tooltip" data-bs-placement="bottom"{% endif %}>
                     <i class="fas fa-search fa-lg" aria-hidden="true"></i>
                     {%- if search_text and search_text != '' -%} {{ search_text }}{%- else -%}<span class="visually-hidden">Search</span>{%- endif -%}
-                </a>
+                </button>
             </li>
             {%- for navlink in site.header_links -%}
             <li class="nav-item">
@@ -42,7 +41,7 @@
                     {% if navlink.tooltip or navlink.text %}aria-label="{{ navlink.tooltip | default: navlink.text }}"{% endif %}
                     {% if navlink.tooltip %}title="{{ navlink.tooltip }}" data-bs-toggle-tooltip="tooltip" data-bs-placement="bottom"{% endif %}>
                     {%- if navlink.fa_class -%}
-                    <i class="{{ navlink.fa_class }} fa-lg"></i>
+                    <i class="{{ navlink.fa_class }} fa-lg" aria-hidden="true"></i>
                     {%- endif -%}
                     {%- if navlink.text and navlink.text != '' -%} {{ navlink.text }}{%- endif -%}
                 </a>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,6 +14,7 @@
                 
                 <!-- TODO: Catpure groupActive and linkActive to apply classes and data props -->
                 {%- if pages.size == 1 -%}
+                <li class="sidebar-nav-item">
                     <a href="{{ pages | map: 'url' | first | relative_url }}"
                     class="bg-dark list-group-item list-group-item-action {% if activeCount > 0 %} active{%- endif -%}"
                     data-sidebar-item="true"
@@ -21,30 +22,35 @@
                     data-bs-placement="right"
                     title="{{ group.name }}"
                     aria-label="{{ group.name }}">
-                        <div class="d-flex w-100 justify-content-start align-items-center">
-                            <span class="{{ group.fa_class }} fa-fw me-3"></span>
+                        <span class="d-flex w-100 justify-content-start align-items-center">
+                            <span class="{{ group.fa_class }} fa-fw me-3" aria-hidden="true"></span>
                             <span class="menu-collapsed sidebar-link-label">{{ group.name }}</span>
-                        </div>
+                        </span>
                     </a>
+                </li>
                 {%- else -%}
-                    <a href="#{{ submenuId }}"
+                <li class="sidebar-nav-item">
+                    <button
+                        type="button"
                         data-bs-toggle="collapse"
+                        data-bs-target="#{{ submenuId }}"
+                        aria-controls="{{ submenuId }}"
                         aria-expanded="{%- if activeCount > 0 -%}true{%- else -%}false{%- endif -%}"
-                        class="bg-dark list-group-item list-group-item-action grou-nav flex-column align-items-start {% if activeCount > 0 %} active{%- endif -%}"
+                        class="bg-dark list-group-item list-group-item-action grou-nav flex-column align-items-start w-100 {% if activeCount > 0 %} active{%- endif -%}"
                         data-sidebar-item="true"
                         data-sidebar-submenu="{{ submenuId }}"
                         data-bs-toggle-tooltip="tooltip"
                         data-bs-placement="right"
                         title="{{ group.name }}"
                         aria-label="{{ group.name }}">
-                        <div class="d-flex w-100 justify-content-start align-items-center">
-                            <span class="{{ group.fa_class }} fa-fw me-3"></span>
+                        <span class="d-flex w-100 justify-content-start align-items-center">
+                            <span class="{{ group.fa_class }} fa-fw me-3" aria-hidden="true"></span>
                             <span class="menu-collapsed sidebar-link-label">{{ group.name }}</span>
-                            <span class="submenu-icon ms-auto submenu-expand fa fa-caret-down"></span>
-                            <span class="submenu-icon ms-auto submenu-collapse fa fa-caret-up"></span>
-                        </div>
-                    </a>
-                    <div id='{{ submenuId }}' class="{%- if activeCount == 0 -%}collapse{%- endif %} sidebar-submenu">
+                            <span class="submenu-icon ms-auto submenu-expand fa fa-caret-down" aria-hidden="true"></span>
+                            <span class="submenu-icon ms-auto submenu-collapse fa fa-caret-up" aria-hidden="true"></span>
+                        </span>
+                    </button>
+                    <div id="{{ submenuId }}" class="{%- if activeCount == 0 -%}collapse{%- endif %} sidebar-submenu">
                         {%- for navPage in pages -%}
                             <a href="{{ navPage.url | relative_url }}"
                                 class="list-group-item list-group-item-action bg-dark text-white {% if page.url == navPage.url %} active{%- endif -%}">
@@ -52,15 +58,18 @@
                             </a>
                         {%- endfor -%}
                     </div>
+                </li>
                 {%- endif -%}
             {%- endfor -%}
         {%- endfor -%}
         
-            <a href="#top" data-sidebar-toggle="collapse" class="bg-dark list-group-item list-group-item-action d-flex align-items-center" data-bs-toggle-tooltip="tooltip" data-bs-placement="right" title="Toggle sidebar" aria-label="Toggle sidebar">
-                <div class="d-flex w-100 justify-content-start align-items-center">
-                    <span id="collapse-icon" class="fa fa-angle-left fa-2x me-3"></span>
+            <li class="sidebar-nav-item">
+            <button type="button" data-sidebar-toggle="collapse" class="bg-dark list-group-item list-group-item-action d-flex align-items-center w-100" data-bs-toggle-tooltip="tooltip" data-bs-placement="right" title="Toggle sidebar" aria-label="Toggle sidebar">
+                <span class="d-flex w-100 justify-content-start align-items-center">
+                    <span id="collapse-icon" class="fa fa-angle-left fa-2x me-3" aria-hidden="true"></span>
                     <span id="collapse-text" class="menu-collapsed">Collapse</span>
-                </div>
-            </a>
+                </span>
+            </button>
+            </li>
     </ul>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,16 +1,18 @@
-<html data-baseurl="{{ '' | relative_url }}">
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: 'en' }}" data-baseurl="{{ '' | relative_url }}">
     {% include head.html %}
     <body>
+        <a class="visually-hidden-focusable" href="#main-content">Skip to main content</a>
         {% include navbar.html %}
         <div id="body-row" class="row">
             {% include sidebar.html %}
-            <div class="col">
+            <main id="main-content" class="col">
                 <div class="container-fluid mt-2">
                     {{ content }}
                 </div>
-            </div>
+            </main>
         </div>
-        <div class="modal fade td-search-modal" id="tdSearchModal" tabindex="-1" aria-labelledby="tdSearchModalLabel" aria-hidden="true" data-search>
+        <div class="modal fade td-search-modal" id="tdSearchModal" tabindex="-1" aria-labelledby="tdSearchModalLabel" data-search>
             <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -38,9 +40,7 @@
                             id="td-doc-search-results"
                             class="td-search-results"
                             data-search-results
-                            hidden
-                            role="listbox"
-                            aria-label="Search results">
+                            hidden>
                         </div>
                     </div>
                 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,7 +7,7 @@ layout: default
             <div class="row">
                 {%- if site.logo_src -%}
                     <div class="col col-md-3 text-end">
-                        <img class="home-logo" src="{{ site.logo_src }}" style="width:100%" />
+                        <img class="home-logo" src="{{ site.logo_src }}" alt="{{ site.brand | default: site.title | default: 'Site logo' }}">
                     </div>
                 {%- endif -%}
                 <div class="col col-md-9 text-start">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -482,6 +482,12 @@ a:hover {
   border-color: rgba(51, 51, 51, 0.125);
 }
 
+.sidebar-nav-item {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 #sidebar-container .list-group-item.bg-dark {
   border-width: 0 1px 1px;
   border-style: solid;
@@ -494,6 +500,11 @@ a:hover {
   background-color: #1d2124 !important;
   color: var(--td-white);
   text-decoration: none;
+}
+
+#sidebar-container button.list-group-item {
+  text-align: left;
+  border-radius: 0;
 }
 
 /* Submenu item */

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -157,7 +157,6 @@
     resultLinks.forEach((link, index) => {
       const isActive = index === normalizedIndex;
       link.classList.toggle("is-active", isActive);
-      link.setAttribute("aria-selected", isActive ? "true" : "false");
     });
 
     activeResultIndex = normalizedIndex;
@@ -222,7 +221,7 @@
     searchResults.hidden = false;
     searchResults.innerHTML = results.map((result) => {
       return `
-        <a class="td-search-result" href="${escapeHtml(result.url)}" role="option" aria-selected="false">
+        <a class="td-search-result" href="${escapeHtml(result.url)}">
           <span class="td-search-result-path">${escapeHtml(result.pathLabel)}</span>
           <span class="td-search-result-title">${escapeHtml(result.titleLabel)}</span>
           ${result.snippet ? `<span class="td-search-result-snippet">${escapeHtml(result.snippet)}</span>` : ""}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,307 @@
+{
+  "name": "owasp-td-jekyll-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "owasp-td-jekyll-dev",
+      "devDependencies": {
+        "html-validate": "^10.11.3"
+      }
+    },
+    "node_modules/@html-validate/stylish": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-5.1.0.tgz",
+      "integrity": "sha512-Tyx/ZbHBpVZjvSleNplNMUhqT4UY1HwAMC97GSmasJXggWuvjNFLBS2scqnEb+ZG1szLq4zgjOioj7cVWV9WuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.11 || >= 22.16"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-4.0.1.tgz",
+      "integrity": "sha512-6arF1ssKxItxgitPYXafUoLmsVBA6K7m9+ZGj6hLDoBl7nWpJ33EInwQUdHTle2METeWGxgQiqSex20KZRykew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "kleur": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "ajv": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/html-validate": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-10.11.3.tgz",
+      "integrity": "sha512-wKUq9iR6bukMgiHhs/ORThZzEbQoFiiPNN7aZfQ8dlmhttPb2sM2Ji2p+Fy5Xj1aH7QHJ1biT2SUDw7A01P2oA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/html-validate"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@html-validate/stylish": "^5.0.0",
+        "@sidvind/better-ajv-errors": "4.0.1",
+        "ajv": "^8.0.0",
+        "glob": "^13.0.0",
+        "kleur": "^4.1.0",
+        "minimist": "^1.2.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >= 22.16.0"
+      },
+      "peerDependencies": {
+        "jest": "^28.1.3 || ^29.0.3 || ^30.0.0",
+        "jest-diff": "^28.1.3 || ^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^28.1.3 || ^29.0.3 || ^30.0.0",
+        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.1"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-diff": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "owasp-td-jekyll-dev",
+  "private": true,
+  "scripts": {
+    "build:site": "bundle exec jekyll build",
+    "check:accessibility": "npm run build:site && html-validate --ext=html _site"
+  },
+  "devDependencies": {
+    "html-validate": "^10.11.3"
+  }
+}


### PR DESCRIPTION
Closes #38 

Adds html-validate to lean on accessibility-related rulesets.
After running, I disabled a couple options that are just noise: no whitespace, SRI for relative paths (I kept enabled for absolute), and style rules around [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element).  None of those are accessibility concerns.

The following items were identified and remediated:
- Missing page language
- Missing skip link
- Missing main landmark
- Wrong control semantics
- Invalid sidebar structure
- Unlabeled icon links
- Missing image alt text
- Over-specified search ARIA

I may have also sneaked in a little `_config.yml` change that excludes all the root-level metadata from builds (readme, gemfile, package.json, etc).