### PR TITLE
Add optional package version display to navbar brand (for #1730 issue in threat-dragon)

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -7,6 +7,7 @@
     </button>
     <a class="navbar-brand" href="{{ '/' | relative_url }}">
         {{ site.brand }}
+        {%- if site.data.package.version %} <span class="navbar-version">v{{ site.data.package.version }}</span>{% endif -%}
     </a>
     <button
         class="nav-link theme-toggle td-mobile-theme-toggle d-md-none ms-auto"


### PR DESCRIPTION
This PR is to solve the issue #1730 in threat-dragon repo by adding following in _includes/navbar.html
```bash
{%- if site.data.package.version %} <span class="navbar-version">v{{ site.data.package.version }}</span>{% endif -%}
```

added a check site.data.package.version in case the package.json file is not in _data/   folder 